### PR TITLE
Update image-classification.md

### DIFF
--- a/doc_source/image-classification.md
+++ b/doc_source/image-classification.md
@@ -41,7 +41,7 @@ The Amazon SageMaker Image Classification algorithm supports both RecordIO \(`ap
 
 ### Inference with Image Format<a name="IC-inference"></a>
 
-The generated models can be hosted for inference and support encoded `.jpg` and `.png` image formats as `application/x-image` content\-type\. The output is the probability values for all classes encoded in JSON format\.
+The generated models can be hosted for inference and support encoded `.jpg` and `.png` image formats as `application/x-image` content\-type\. The input image will be resized automatically. The output is the probability values for all classes encoded in JSON format\.
 
 For more details on training and inference, see the image classification sample notebook instances\.
 


### PR DESCRIPTION
In the sample notebook, the input image is not explicitly resized before being posted to the prediction input. I have to assume that this is done automatically by the endpoint. If so, it should be mentioned in the documentation. If not, then the notebook should be fixed :)

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
