### PR TITLE
Update ex1-batch-transform.md high-level API

### DIFF
--- a/doc_source/ex1-batch-transform.md
+++ b/doc_source/ex1-batch-transform.md
@@ -87,7 +87,7 @@ To run a batch transform, you create a transform job with the `CreateTransformJo
 The following shows how to create a transform job using the High\-level Python Library:
 
 ```
-    import sagemaker
+    from sagemaker.transformer import Transformer
     from time import gmtime, strftime
     
     job_name = 'Batch-Transform-' + strftime("%Y-%m-%d-%H-%M-%S", gmtime())
@@ -97,9 +97,12 @@ The following shows how to create a transform job using the High\-level Python L
     
     # Initialize the transformer object
     transformer = Transformer(model_name=my_model_name,
-                            transform_job_name=job_name,
+                            instance_count=1,
+                            instance_type='ml.m4.xlarge',
+                            base_transform_job_name=job_name,
                             output_path="s3://{}/{}/Batch-Transform/".format(bucket,prefix)
-                            )
+                            ) 
+
     # To start a transform job:                        
     transformer.transform("s3://{}/{}/Batch-Transform/".format(bucket,prefix)”/output”)
     


### PR DESCRIPTION
When I try to execute High-level Python Library code in a Sagemaker notebook with the conda_python3 kernel, I receive the error below. I suggested modifications that I think will work. I don't know what is intended in the transformer.transform() call. The ”/output” portion of that line doesn't seem like correct Python syntax to me.

It would be helpful if the example showed how to use the MNIST data and kmeans model that was used previously in the tutorial in a batch transformation.

---------------------------------------------------------------------------
NameError                                 Traceback (most recent call last)
<ipython-input-2-7e710140d094> in <module>()
      8 
      9 # Initialize the transformer object
---> 10 transformer = Transformer(model_name=my_model_name,
     11                         transform_job_name=job_name,
     12                         output_path="s3://{}/{}/Batch-Transform/".format(bucket,prefix)

NameError: name 'Transformer' is not defined

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
