### PR TITLE
Fix one bug that “"Type": "Integer"” is outside hyperparameters.json

### DIFF
--- a/doc_source/sagemaker-mkt-create-algo.md
+++ b/doc_source/sagemaker-mkt-create-algo.md
@@ -81,9 +81,9 @@ You can create an algorithm by using either the Amazon SageMaker console or the 
       "IntegerParameterRangeSpecification": {
       "MaxValue": "10",
       "MinValue": "1"
-      }
       },
       "Type": "Integer"
+      }
       ```
 
       In the JSON, supply the following:


### PR DESCRIPTION
Fix one bug that “"Type": "Integer"” is outside hyperparameters.json

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
