### PR TITLE
Fix Typo in model-managed-spot-training.md

### DIFF
--- a/doc_source/model-managed-spot-training.md
+++ b/doc_source/model-managed-spot-training.md
@@ -4,7 +4,7 @@ Amazon SageMaker makes it easy to train machine learning models using managed Am
 
 Managed Spot Training uses Amazon EC2 Spot instance to run training jobs instead of on\-demand instances\. You can specify which training jobs use spot instances and a stopping condition that specifies how long SageMaker waits for a job to run using Amazon EC2 Spot instances\. Metrics and logs generated during training runs are available in CloudWatch\. 
 
-Amazon SageMaker automatic model tuning, also known as hyperparameter tuning, can use managed spot training\. For more information on automatic model training, see [Perform Automatic Model Tuning with SageMaker](automatic-model-tuning.md)\.
+Amazon SageMaker automatic model tuning, also known as hyperparameter tuning, can use managed spot training\. For more information on automatic model tuning, see [Perform Automatic Model Tuning with SageMaker](automatic-model-tuning.md)\.
 
 Spot instances can be interrupted, causing jobs to take longer to start or finish\. You can configure your managed spot training job to use checkpoints\. SageMaker copies checkpoint data from a local path to Amazon S3\. When the job is restarted, SageMaker copies the data from Amazon S3 back into the local path\. The training job can then resume from the last checkpoint instead of restarting\. For more information about checkpointing, see [Use Checkpoints in Amazon SageMaker](model-checkpoints.md)\.
 


### PR DESCRIPTION
*Issue #, if available:*
None

*Description of changes:*
`automatic model tuning` was mentioned as `automatic model training`. I guess it was a typo.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
