### PR TITLE
Remove spaces in CollectionConfig URL

### DIFF
--- a/doc_source/debugger-configure-hook.md
+++ b/doc_source/debugger-configure-hook.md
@@ -42,7 +42,7 @@ collection_configs=[
 ]
 ```
 
-For more information about available parameter keys, see [CollectionConfig](https://sagemaker.readthedocs.io/en/stable/api/training/debugger.html                 #sagemaker.debugger.CollectionConfig) in the [Amazon SageMaker Python SDK](https://sagemaker.readthedocs.io)\. For example, the following code example shows how you can adjust the save intervals of the "losses" tensor collection at different phases of training: save loss every 100 steps in training phase and validation loss every 10 steps in validation phase\. 
+For more information about available parameter keys, see [CollectionConfig](https://sagemaker.readthedocs.io/en/stable/api/training/debugger.html#sagemaker.debugger.CollectionConfig) in the [Amazon SageMaker Python SDK](https://sagemaker.readthedocs.io)\. For example, the following code example shows how you can adjust the save intervals of the "losses" tensor collection at different phases of training: save loss every 100 steps in training phase and validation loss every 10 steps in validation phase\. 
 
 ```
 from sagemaker.debugger import CollectionConfig


### PR DESCRIPTION
Because of these spaces in the URL, users get a 404 when opening https://sagemaker.readthedocs.io/en/stable/api/training/debugger.html%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20#sagemaker.debugger.CollectionConfig

*Issue #, if available:*

*Description of changes:*
I removed spaces in CollectionConfig URL

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
