### PR TITLE
Update clarify-data-bias-metric-cddl.md

### DIFF
--- a/doc_source/clarify-data-bias-metric-cddl.md
+++ b/doc_source/clarify-data-bias-metric-cddl.md
@@ -28,7 +28,7 @@ The demographic disparity for a subgroup \(DDi\) are the difference between the 
 
 The range of DD values for binary outcomes is \(\-1, \+1\)\. 
 + \+1: when there are no rejections in facet *a* or subgroup and no acceptances in facet *d* or subgroup
-+ Positive values indicate there is a demographic disparity as facet *d* or subgroup has a smaller proportion of the rejected outcomes in the dataset than of the accepted outcomes\. The higher the value the greater the disparity\.
++ Positive values indicate there is a demographic disparity as facet *a* or subgroup has a smaller proportion of the rejected outcomes in the dataset than of the accepted outcomes\. The higher the value the greater the disparity\.
 + Negative values indicate there is a demographic disparity as facet *a* or subgroup has a larger proportion of the rejected outcomes in the dataset than of the accepted outcomes\. The lower the value the greater the disparity\.
 + \-1: when there are no rejections in facet *d* or subgroup and no acceptances in facet *a* or subgroup
 


### PR DESCRIPTION
Current explanation for positive values is incorrect and disagrees with the example, should either say that facet a has a smaller proportion of rejected outcomes or that facet d has a larger proportion.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
