### PR TITLE
Update automatic-model-tuning-warm-start.md

### DIFF
--- a/doc_source/automatic-model-tuning-warm-start.md
+++ b/doc_source/automatic-model-tuning-warm-start.md
@@ -105,7 +105,7 @@ from sagemaker.tuner import WarmStartConfig,
           WarmStartTypes
 
 parent_tuning_job_name = "MyParentTuningJob"
-warm_start_config = WarmStartConfig(type=WarmStartTypes.IDENTICAL_DATA_AND_ALGORITHM, parents={parent_tuning_job_name})
+warm_start_config = WarmStartConfig(warm_start_type=WarmStartTypes.IDENTICAL_DATA_AND_ALGORITHM, parents={parent_tuning_job_name})
 ```
 
 Now set the values for static hyperparameters, which are hyperparameters that keep the same value for every training job that the warm start tuning job launches\. In the following code, `imageclassification` is an estimator that was created previously\.


### PR DESCRIPTION
Line 108 uses the wrong param name for the warm up start type.

reference:
according to https://github.com/aws/sagemaker-python-sdk/blob/master/src/sagemaker/tuner.py#L111.

type --> warm_start_type.
