### PR TITLE
fix: argument name in SageMaker recommender

### DIFF
--- a/doc_source/inference-recommender-instance-recommendation.md
+++ b/doc_source/inference-recommender-instance-recommendation.md
@@ -111,7 +111,7 @@ Once an instance recommendation is complete, you can use `DescribeInferenceRecom
 ```
 job_name='<INSERT>'
 response = sagemaker_client.describe_inference_recommendations_job(
-                    job_name=job_name)
+                    JobName=job_name)
 ```
 
 Print the response object\. The previous code sample stored the response in a variable name `response`\.
@@ -339,7 +339,7 @@ Specify the name of the instance recommendation job for the `JobName` field:
 
 ```
 sagemaker_client.stop_inference_recommendations_job(
-                                    job_name='<INSERT>'
+                                    JobName='<INSERT>'
                                     )
 ```
 

--- a/doc_source/inference-recommender-load-test.md
+++ b/doc_source/inference-recommender-load-test.md
@@ -396,7 +396,7 @@ Specify the job name of the load test for the `JobName` field:
 
 ```
 sagemaker_client.stop_inference_recommendations_job(
-                                    job_name='<INSERT>'
+                                    JobName='<INSERT>'
                                     )
 ```
 


### PR DESCRIPTION
*Description of changes:*
Fix argument name in Python SDK in SageMaker Inference Recommender doc

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
