### PR TITLE
Fix model loading for later versions of XGBoost.

### DIFF
--- a/doc_source/define-pipeline.md
+++ b/doc_source/define-pipeline.md
@@ -417,7 +417,8 @@ This section shows how to create a processing step to evaluate the accuracy of 
        with tarfile.open(model_path) as tar:
            tar.extractall(path=".")
        
-       model = pickle.load(open("xgboost-model", "rb"))
+       model = xgboost.Booster()
+       model.load_model("xgboost-model")
    
        test_path = "/opt/ml/processing/test/test.csv"
        df = pd.read_csv(test_path, header=None)


### PR DESCRIPTION
The old method doesn't work for XGBoost versions >= 1.3 https://stackoverflow.com/a/70098541/6179774


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
