### PR TITLE
update exception type as wrong parameter name used

### DIFF
--- a/doc_source/pipelines-retry-policy.md
+++ b/doc_source/pipelines-retry-policy.md
@@ -110,7 +110,7 @@ step_train = TrainingStep(
         ),
         // retry when job failed due to transient error or EC2 ICE.
         SageMakerJobStepRetryPolicy(
-            failure_reason_types=[
+            exception_types=[
                 SageMakerJobExceptionTypeEnum.INTERNAL_ERROR,
                 SageMakerJobExceptionTypeEnum.CAPACITY_ERROR,
             ]


### PR DESCRIPTION
Change "failure_reason_types" to "exception_types" in line 113

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
