### PR TITLE
Fix a Typo

### DIFF
--- a/doc_source/nbi-add-external.md
+++ b/doc_source/nbi-add-external.md
@@ -23,7 +23,7 @@ You can install packages using the following methods:
   + `%pip install`
 + The Jupyter terminal – You can install packages using pip and conda directly\.
 
-From within a notebook you can use the system command syntax \(lines starting with \!\) to install packages, for example, `!pip install` and `!conda install`\. More recently, new commands have been added to IPython: `%pip` and `%conda`\. These commands are the recommended way to install packages from a notebook as they correctly take into account the activate environment or interpreter being used\. For more information, see [Add %pip and %conda magic functions](https://github.com/ipython/ipython/pull/11524)\.
+From within a notebook you can use the system command syntax \(lines starting with \!\) to install packages, for example, `!pip install` and `!conda install`\. More recently, new commands have been added to IPython: `%pip` and `%conda`\. These commands are the recommended way to install packages from a notebook as they correctly take into account the active environment or interpreter being used\. For more information, see [Add %pip and %conda magic functions](https://github.com/ipython/ipython/pull/11524)\.
 
 ### Conda<a name="nbi-add-external-tools-conda"></a>
 


### PR DESCRIPTION
Fixes the same typo in [Install External Libraries and Kernels in Notebook Instances](https://docs.aws.amazon.com/sagemaker/latest/dg/nbi-add-external.html)
 that was also in [Install External Libraries and Kernels in Amazon SageMaker Studio](https://docs.aws.amazon.com/sagemaker/latest/dg/studio-notebooks-add-external.html): (https://github.com/awsdocs/amazon-sagemaker-developer-guide/pull/243).

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
