### PR TITLE
add a few important required dependencies to make Sagemaker studio work

### DIFF
--- a/doc_source/studio-notebooks-and-internet-access.md
+++ b/doc_source/studio-notebooks-and-internet-access.md
@@ -28,7 +28,7 @@ You can configure only subnets with a default tenancy VPC in which your instance
 
 3. If you want to allow internet access, you must use a [NAT gateway](https://docs.aws.amazon.com/vpc/latest/userguide/vpc-nat-gateway.html#nat-gateway-working-with) with access to the internet, for example through an [internet gateway](https://docs.aws.amazon.com/vpc/latest/userguide/VPC_Internet_Gateway.html)\.
 
-4. If you don't want to allow internet access, [create interface VPC endpoints](https://docs.aws.amazon.com/vpc/latest/privatelink/vpce-interface.html) \(AWS PrivateLink\) to allow Studio to access the following services with the corresponding service names\. Ensure that you enabled the private DNS name for all VPC endpoints. You must also associate the security groups for your VPC with these endpoints\.
+4. If you don't want to allow internet access, [create interface VPC endpoints](https://docs.aws.amazon.com/vpc/latest/privatelink/vpce-interface.html) \(AWS PrivateLink\) to allow Studio to access the following services with the corresponding service names\. You must also associate the security groups for your VPC with these endpoints\.
    + SageMaker API : `com.amazonaws.us-east-1.sagemaker.api`
    + SageMaker runtime: `com.amazonaws.us-east-1.sagemaker.runtime`\. This is required to run Studio notebooks and to train and host models\.
    + Amazon S3: `com.amazonaws.us-east-1.s3`\.

--- a/doc_source/studio-notebooks-and-internet-access.md
+++ b/doc_source/studio-notebooks-and-internet-access.md
@@ -19,7 +19,7 @@ To prevent SageMaker from providing internet access to your Studio notebooks, yo
 When you choose `VpcOnly`, follow these steps:
 
 1. Ensure your subnets have the required number of IP addresses needed\.The expected number of IP addresses needed per user can vary based on use case\. We recommend between 2 and 4 IP addresses per user\. The total IP address capacity for a Studio domain is the sum of available IP addresses for each subnet provided when the domain is created\. Ensure that your estimated IP address usage does not exceed the capacity supported by the number of subnets you provide\. Additionally, using subnets distributed across many availability zones can aid in IP address availability\. For more information, see [VPC and subnet sizing for IPv4](https://docs.aws.amazon.com/vpc/latest/userguide/VPC_Subnets.html#vpc-sizing-ipv4)\.
-**Note**  
+**Note**
 You can configure only subnets with a default tenancy VPC in which your instance runs on shared hardware\. For more information on the tenancy attribute for VPCs, see [Dedicated Instances](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/dedicated-instance.html)\.
 
 1. Set up one or more security groups with inbound and outbound rules that together allow the following traffic:
@@ -28,15 +28,17 @@ You can configure only subnets with a default tenancy VPC in which your instance
 
 1. If you want to allow internet access, you must use a [NAT gateway](https://docs.aws.amazon.com/vpc/latest/userguide/vpc-nat-gateway.html#nat-gateway-working-with) with access to the internet, for example through an [internet gateway](https://docs.aws.amazon.com/vpc/latest/userguide/VPC_Internet_Gateway.html)\.
 
-1. If you don't want to allow internet access, [create interface VPC endpoints](https://docs.aws.amazon.com/vpc/latest/privatelink/vpce-interface.html) \(AWS PrivateLink\) to allow Studio to access the following services with the corresponding service names\. You must also associate the security groups for your VPC with these endpoints\.
-   + SageMaker API : `com.amazonaws.us-east-1.sagemaker.api` 
-   + SageMaker runtime: `com.amazonaws.us-east-1.sagemaker.runtime`\. This is required to run Studio notebooks and to train and host models\. 
+1. If you don't want to allow internet access, [create interface VPC endpoints](https://docs.aws.amazon.com/vpc/latest/privatelink/vpce-interface.html) \(AWS PrivateLink\) to allow Studio to access the following services with the corresponding service names\. Ensure that you enabled the private DNS name for all VPC endpoints. You must also associate the security groups for your VPC with these endpoints\.
+   + SageMaker API : `com.amazonaws.us-east-1.sagemaker.api`
+   + SageMaker runtime: `com.amazonaws.us-east-1.sagemaker.runtime`\. This is required to run Studio notebooks and to train and host models\.
    + Amazon S3: `com.amazonaws.us-east-1.s3`\.
+   + AWS Security Token Service: `com.amazonaws.us-east-1.sts`\. This is required to run remote training job.
+   + Amazon CloudWatch: `com.amazonaws.us-east-1.logs`\. This is required to allow Sagemaker SDK to get the remote training job status via CloudWatch.
    + To use SageMaker Projects: `com.amazonaws.us-east-1.servicecatalog`\.
    + Any other AWS services you require\.
 
-**Note**  
-For a customer working within VPC mode, company firewalls can cause connection issues with SageMaker Studio or between JupyterServer and the KernelGateway\. Make the following checks if you encounter one of these issues when using SageMaker Studio from behind a firewall\.  
+**Note**
+For a customer working within VPC mode, company firewalls can cause connection issues with SageMaker Studio or between JupyterServer and the KernelGateway\. Make the following checks if you encounter one of these issues when using SageMaker Studio from behind a firewall\.
 Check that the Studio URL is in your networks allowlist\.
 Check that the websocket connections are not blocked\. Jupyter uses websocket under the hood\. If the KernelGateway application is InService, JupyterServer may not be able to connect to the KernelGateway\. You should see this problem when opening System Terminal as well\.
 

--- a/doc_source/studio-notebooks-and-internet-access.md
+++ b/doc_source/studio-notebooks-and-internet-access.md
@@ -22,20 +22,22 @@ When you choose `VpcOnly`, follow these steps:
 **Note**
 You can configure only subnets with a default tenancy VPC in which your instance runs on shared hardware\. For more information on the tenancy attribute for VPCs, see [Dedicated Instances](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/dedicated-instance.html)\.
 
-1. Set up one or more security groups with inbound and outbound rules that together allow the following traffic:
+2. Set up one or more security groups with inbound and outbound rules that together allow the following traffic:
    + [NFS traffic over TCP on port 2049](https://docs.aws.amazon.com/efs/latest/ug/network-access.html) between the domain and the Amazon EFS volume\.
    + [TCP traffic within the security group](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/security-group-rules-reference.html#sg-rules-other-instances)\. This is required for connectivity between the JupyterServer app and the KernelGateway apps\. You must allow access to at least ports in the range `8192-65535`\.
 
-1. If you want to allow internet access, you must use a [NAT gateway](https://docs.aws.amazon.com/vpc/latest/userguide/vpc-nat-gateway.html#nat-gateway-working-with) with access to the internet, for example through an [internet gateway](https://docs.aws.amazon.com/vpc/latest/userguide/VPC_Internet_Gateway.html)\.
+3. If you want to allow internet access, you must use a [NAT gateway](https://docs.aws.amazon.com/vpc/latest/userguide/vpc-nat-gateway.html#nat-gateway-working-with) with access to the internet, for example through an [internet gateway](https://docs.aws.amazon.com/vpc/latest/userguide/VPC_Internet_Gateway.html)\.
 
-1. If you don't want to allow internet access, [create interface VPC endpoints](https://docs.aws.amazon.com/vpc/latest/privatelink/vpce-interface.html) \(AWS PrivateLink\) to allow Studio to access the following services with the corresponding service names\. Ensure that you enabled the private DNS name for all VPC endpoints. You must also associate the security groups for your VPC with these endpoints\.
+4. If you don't want to allow internet access, [create interface VPC endpoints](https://docs.aws.amazon.com/vpc/latest/privatelink/vpce-interface.html) \(AWS PrivateLink\) to allow Studio to access the following services with the corresponding service names\. Ensure that you enabled the private DNS name for all VPC endpoints. You must also associate the security groups for your VPC with these endpoints\.
    + SageMaker API : `com.amazonaws.us-east-1.sagemaker.api`
    + SageMaker runtime: `com.amazonaws.us-east-1.sagemaker.runtime`\. This is required to run Studio notebooks and to train and host models\.
    + Amazon S3: `com.amazonaws.us-east-1.s3`\.
-   + AWS Security Token Service: `com.amazonaws.us-east-1.sts`\. This is required to run remote training job.
-   + Amazon CloudWatch: `com.amazonaws.us-east-1.logs`\. This is required to allow Sagemaker SDK to get the remote training job status via CloudWatch.
    + To use SageMaker Projects: `com.amazonaws.us-east-1.servicecatalog`\.
    + Any other AWS services you require\.
+
+5. If you use [Sagemaker Python SDK](https://sagemaker.readthedocs.io/en/stable/) to run remote training job. You need to create additional VPC endpoints.  
+   + AWS Security Token Service: `com.amazonaws.us-east-1.sts`\. This is required to run remote training job.
+   + Amazon CloudWatch: `com.amazonaws.us-east-1.logs`\. This is required to allow Sagemaker SDK to get the remote training job status via CloudWatch.
 
 **Note**
 For a customer working within VPC mode, company firewalls can cause connection issues with SageMaker Studio or between JupyterServer and the KernelGateway\. Make the following checks if you encounter one of these issues when using SageMaker Studio from behind a firewall\.


### PR DESCRIPTION
**Why make this changes**

I am an AWS Solution Architect. When helping a customer setting up Sagemaker Domain for ML development in Sagemaker Studio, we were following this document https://docs.aws.amazon.com/sagemaker/latest/dg/studio-notebooks-and-internet-access.html#studio-notebooks-and-internet-access-vpc. The customer was running into a series of issue. Eventually, with a support solution architect, we figured out that there are some steps are not mentioned in the official docs:

- All VPC Endpoints need to enable private DNS name. Otherwise, you cannot connect to Sagemaker studio from the AWS Console
- You have to create STS VPC Endpoint. Otherwise, you will receive an "STS Permission Error" when you want to use [sagemaker SDK](https://sagemaker.readthedocs.io/en/stable/) to run a remote training job. However, the error message is little bit misleading. Actually it is because the SDK cannot talk to STS API to get the access.
- You have to create Cloudwatch log VPC Endpoint. Otherwise, when you are running a remote training job, the SDK will freeze and show ``Starting`` forever. Even though the remote job is already finished in Sagemaker console. This is because the SDK use the cloudwatch API to get the status of the Sagemaker training job.

**I would like to update the document to avoid more AWS customers running into the same issue.**

**Description of changes:**

- ensure that the private DNS name is enabled for all VPC endpoint
- also need sts and cloudwatch logs VPC endpoints
