### PR TITLE
Correct object name while invoking endpoint.

### DIFF
--- a/doc_source/serverless-endpoints-invoke.md
+++ b/doc_source/serverless-endpoints-invoke.md
@@ -20,7 +20,7 @@ endpoint_name = "<your-endpoint-name>"
 content_type = "<request-mime-type>"
 payload = <your-request-body>
 
-response = client.invoke_endpoint(
+response = runtime.invoke_endpoint(
     EndpointName=endpoint_name,
     ContentType=content_type,
     Body=payload


### PR DESCRIPTION
 The Sagemaker client object has no attribute 'invoke_endpoint', it's in Sagemaker 'runtime'.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
