### PR TITLE
Fix error in placement of 'SecurityGroups' config within --default-space-settings example for VPCOnly domains.

### DIFF
--- a/doc_source/domain-space-create.md
+++ b/doc_source/domain-space-create.md
@@ -50,7 +50,7 @@ sagemaker update-domain \
 aws --region region \
 sagemaker update-domain \
 --domain-id domain-id \
---default-space-settings "ExecutionRole=execution-role-arn,JupyterServerAppSettings={DefaultResourceSpec={InstanceType=system,SageMakerImageArn=sagemaker-image-arn},SecurityGroups=[security-groups]}"
+--default-space-settings "ExecutionRole=execution-role-arn,JupyterServerAppSettings={DefaultResourceSpec={InstanceType=system,SageMakerImageArn=sagemaker-image-arn}},SecurityGroups=[security-groups]"
 ```
 
  Verify that the default shared space settings have been updated\. 


### PR DESCRIPTION
The existing code example leads to a validation error: 'Unknown parameter in DefaultSpaceSettings.JupyterServerAppSettings: "SecurityGroups", must be one of: DefaultResourceSpec, LifecycleConfigArns, CodeRepositories'.

As per docs here https://awscli.amazonaws.com/v2/documentation/api/latest/reference/sagemaker/update-domain.html, 'SecurityGroups' config should sit outside of 'JupyterServerAppSettings'.

*Issue #, if available:*

*Description of changes:*

Moved single '}' character to move 'SecurityGroups' config outside of 'JupyterServerAppSettings' mapping.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
