### PR TITLE
Fix non-space whitespace characters

### DIFF
--- a/doc_source/domain-user-profile-add-remove.md
+++ b/doc_source/domain-user-profile-add-remove.md
@@ -64,17 +64,17 @@
 To create a user profile in a Domain from the AWS CLI, run the following command from the terminal of your local machine\. For information about the available JupyterLab version ARNs, see [Setting a default JupyterLab version](studio-jl.md#studio-jl-set)\.
 
 ```
-aws --region region \
+aws --region region \
 sagemaker create-user-profile \
---domain-id domain-id \
+--domain-id domain-id \
 --user-profile-name user-name \
 --user-settings '{
-  "JupyterServerAppSettings": {
-    "DefaultResourceSpec": {
-      "SageMakerImageArn": "sagemaker-image-arn",
-      "InstanceType": "system"
-    }
-  }
+  "JupyterServerAppSettings": {
+    "DefaultResourceSpec": {
+      "SageMakerImageArn": "sagemaker-image-arn",
+      "InstanceType": "system"
+    }
+  }
 }'
 ```
 


### PR DESCRIPTION
When copy-pasting this command it didn't work because some of these spaces are in fact another character that just looks like a space, which Bash is unable to interpret as a space.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
