### PR TITLE
Fix sample Dockerfile

### DIFF
--- a/doc_source/studio-byoi-specs.md
+++ b/doc_source/studio-byoi-specs.md
@@ -52,7 +52,7 @@ ARG NB_UID="1000"
 ARG NB_GID="100"
 
 RUN \
-    yum install --assumeyes python3 shadow-utils && \
+    yum install --assumeyes gcc python3-devel shadow-utils && \
     useradd --create-home --shell /bin/bash --gid "${NB_GID}" --uid ${NB_UID} ${NB_USER} && \
     yum clean all && \
     python3 -m pip install ipykernel && \


### PR DESCRIPTION
*Issue #, if available:* N/a

*Description of changes:*

The provided image did not actually build due to missing `gcc` and `python3-devel` dependencies, which caused a failure when building the wheel for `psutil`.
Trace: 

```
#5 33.21   psutil/_psutil_common.c:9:10: fatal error: Python.h: No such file or directory
#5 33.21    #include <Python.h>
#5 33.21             ^~~~~~~~~~
#5 33.21   compilation terminated.
#5 33.21   psutil could not be installed from sources. Perhaps Python header files are not installed. Try running:
#5 33.21     sudo yum install gcc python3-devel
#5 33.21   error: command '/usr/bin/gcc' failed with exit code 1
#5 33.21   ----------------------------------------
#5 33.21   ERROR: Failed building wheel for psutil
#5 33.21 Failed to build psutil
#5 33.21 ERROR: Could not build wheels for psutil which use PEP 517 and cannot be installed directly
```

Adding `gcc` and changing `python3` to `python3-devel` addressed the issue.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
